### PR TITLE
Proposed interface for handling multiple config file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Creates a configured test case object that can be used for validation.
 
 ```
 test_case = TestCase(
-  filepath='string'  
+  test_case_config=TestCaseConfig()
 )
 ```
 
@@ -42,7 +42,48 @@ test_case = TestCase(
 
 **Usage Example**
 ```
-test_case = TestCase("./config/bsmLogDuringEvent.ini")
+test_case = TestCase(test_case_config)
+```
+
+### `TestCaseConfig(**kwargs)`
+
+Creates a configuration for test cases. Message recordType is extracted during validation and used to determine which validation should be performed.
+
+**Request Syntax**
+
+```
+test_case_config = TestCaseConfig(
+  bsmLogDuringEvent_config_path='string',
+  rxMsg_config_path='string',
+  dnsMsg_config_path='string',
+  bsmTx_config_path='string',
+  driverAlert='string'
+)
+```
+
+**Parameters**
+
+At least one of the following keyword arguments must be specified:
+
+- **bsmLogDuringEvent_config_path** (_string_) \[_optional_\] Relative or absolute path to bsmLogDuringEvent configuration file (see more information in the configuration section below).
+- **rxMsg_config_path** (_string_) \[_optional_\] Relative or absolute path to rxMsg configuration file.
+- **dnsMsg_config_path** (_string_) \[_optional_\] Relative or absolute path to dnsMsg configuration file.
+- **bsmTx_config_path** (_string_) \[_optional_\] Relative or absolute path to bsmTx configuration file.
+- **driverAlert_config_path** (_string_) \[_optional_\] Relative or absolute path to driverAlert configuration file.
+
+**Return Type**
+
+`Object`
+
+**Usage Example**
+```
+test_case_config = TestCaseConfig(
+  bsmLogDuringEvent_config_path='./config/bsmLogDuringEvent.ini',
+  rxMsg_config_path='./config/rxMsg.ini',
+  dnsMsg_config_path='./config/dnsMsg.ini',
+  bsmTx_config_path='./config/bsmTx.ini',
+  driverAlert='./config/driverAlert.ini'
+)
 ```
 
 ### `.validate(**kwargs)`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ test_case = TestCase(
 
 **Parameters**
 
-- **filepath** (_string_) \[REQUIRED\] Relative or absolute path to configuration file (see more information in the configuration section below).
+- **test_case_config** (_string_) \[REQUIRED\] Test case configuration object (see TestCaseConfig below).
 
 **Return Type**
 


### PR DESCRIPTION
Per ODE-1232 there is a need for the validation library to be able to handle multiple types of messages in one file, as well as multiple types of files.

In addition this feature is a blocking requirement for the canary lambda function to be able to dynamically validate a list of many message types.

I propose the following to resolve this issue:

1. A `TestCaseConfig` object that is constructed by passing SPECIFIC file type configuration paths to keyword arguments.
2. An internal switch inside the validation library that will check `recordType` field in the metadata and then validate that record using the appropriate config file type. Missing config file type or unknown recordType would mean an invalid record.