### PR TITLE
Initialize module imports using init script to remove namespace requirement

### DIFF
--- a/odevalidator/__init__.py
+++ b/odevalidator/__init__.py
@@ -1,0 +1,3 @@
+from .validator import *
+from .result import *
+from .sequential import *

--- a/odevalidator/sequential.py
+++ b/odevalidator/sequential.py
@@ -1,7 +1,7 @@
 import json
 import dateutil.parser
 import copy
-from odevalidator.result import ValidationResult
+from .result import ValidationResult
 
 class Sequential:
     def __init__(self):

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -5,8 +5,8 @@ import logging
 from decimal import Decimal
 from pathlib import Path
 import queue
-from odevalidator.result import ValidationResult, ValidatorException
-from odevalidator.sequential import Sequential
+from .result import ValidationResult, ValidatorException
+from .sequential import Sequential
 
 TYPE_DECIMAL = 'decimal'
 TYPE_ENUM = 'enum'
@@ -157,14 +157,14 @@ def test_file(validator, data_file):
         content = f.readlines()
 
     # remove whitespace characters like `\n` at the end of each line
-    content = [x.strip() for x in content] 
+    content = [x.strip() for x in content]
     #msgs = [json.loads(line) for line in content]
 
     q = queue.Queue()
     for msg in content:
         q.put(msg)
 
-    results = validator.validate_queue(q)    
+    results = validator.validate_queue(q)
 
     return results
 


### PR DESCRIPTION
Currently one must use the import namespace (the period) to import classes from the odevalidator package:
```
from odevalidator.validator import TestCase
from odevalidator.result import ValidationResult
from odevalidator.sequential import Sequential
```

However by using [relative imports](https://stackoverflow.com/questions/36502614/a-module-init-py-from-a-folder-cannot-import-the-modules-in-that-folder) you can remove the need for namespacing so all of those imports become:

```
from odevalidator import TestCase
from odevalidator import ValidationResult
from odevalidator import Sequential
```