### PR TITLE
Configuration Improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-pip install --upgrade ./
+pip install --upgrade .

--- a/odevalidator/__main__.py
+++ b/odevalidator/__main__.py
@@ -1,0 +1,3 @@
+# Tests go here
+print("Executing local tests...")
+print("There were none!")

--- a/odevalidator/sequential.py
+++ b/odevalidator/sequential.py
@@ -1,7 +1,7 @@
 import json
 import dateutil.parser
 import copy
-from odevalidator.result import ValidationResult
+from .result import ValidationResult
 
 class Sequential:
     def __init__(self):

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import queue
 from collections.abc import Iterable
 import pkg_resources
-from io import BytesIO
 
 from .result import ValidationResult, ValidatorException
 from .sequential import Sequential
@@ -113,7 +112,7 @@ class TestCase:
         self.config = configparser.ConfigParser()
         if filepath is None:
             default_config = pkg_resources.resource_string(__name__, "config.ini")
-            self.config.read_string(BytesIO(default_config))
+            self.config.read_string(str(default_config, 'utf-8'))
         else:
             assert Path(filepath).is_file(), "Custom configuration file '%s' could not be found" % filepath
             self.config.read(filepath)

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import queue
 from collections.abc import Iterable
 import pkg_resources
+from io import BytesIO
 
 from .result import ValidationResult, ValidatorException
 from .sequential import Sequential
@@ -112,7 +113,7 @@ class TestCase:
         self.config = configparser.ConfigParser()
         if filepath is None:
             default_config = pkg_resources.resource_string(__name__, "config.ini")
-            self.config.read_string(default_config)
+            self.config.read_string(BytesIO(default_config))
         else:
             assert Path(filepath).is_file(), "Custom configuration file '%s' could not be found" % filepath
             self.config.read(filepath)

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from pathlib import Path
 import queue
 from collections.abc import Iterable
+import pkg_resources
 
 from .result import ValidationResult, ValidatorException
 from .sequential import Sequential
@@ -107,10 +108,15 @@ class Field:
 
 
 class TestCase:
-    def __init__(self, filepath="config.ini"):
-        assert Path(filepath).is_file(), "Configuration file '%s' could not be found" % filepath
+    def __init__(self, filepath=None):
         self.config = configparser.ConfigParser()
-        self.config.read(filepath)
+        if filepath is None:
+            default_config = pkg_resources.resource_string(__name__, "config.ini")
+            self.config.read_string(default_config)
+        else:
+            assert Path(filepath).is_file(), "Custom configuration file '%s' could not be found" % filepath
+            self.config.read(filepath)
+
         self.field_list = []
         for key in self.config.sections():
             self.field_list.append(Field(self.config[key]))

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import queue
 from collections.abc import Iterable
 
-from odevalidator.result import ValidationResult, ValidatorException
-from odevalidator.sequential import Sequential
+from .result import ValidationResult, ValidatorException
+from .sequential import Sequential
 
 TYPE_DECIMAL = 'decimal'
 TYPE_ENUM = 'enum'
@@ -82,7 +82,7 @@ class Field:
     def check_value(self, data_field_value, data):
         validations = []
         equals_value = json.loads(self.equals_value)
-        
+
         if isinstance(equals_value, Iterable):
             if 'startsWithField' in equals_value:
                 sw_field_name = equals_value['startsWithField']
@@ -107,16 +107,13 @@ class Field:
 
 
 class TestCase:
-    def __init__(self, filepath="odevalidator/config.ini"):
+    def __init__(self, filepath="config.ini"):
         assert Path(filepath).is_file(), "Configuration file '%s' could not be found" % filepath
         self.config = configparser.ConfigParser()
         self.config.read(filepath)
         self.field_list = []
         for key in self.config.sections():
-            if key == "_settings":
-                continue
-            else:
-                self.field_list.append(Field(self.config[key]))
+            self.field_list.append(Field(self.config[key]))
 
     def _validate(self, data):
         validations = []
@@ -134,7 +131,7 @@ class TestCase:
         msg_list = []
         while not msg_queue.empty():
             line = msg_queue.get()
-            if line and not str.startswith(str(line), '#'):
+            if line and not line.startswith('#'):
                 current_msg = json.loads(line)
                 msg_list.append(current_msg)
                 record_id = str(current_msg['metadata']['serialId']['recordId'])

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(
     author_email="fake@email.com",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'odevalidator': ['config.ini']},
+    package_data={'odevalidator': ['odevalidator/config.ini']},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(
     author_email="fake@email.com",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'': ['odevalidator/config.ini']},
+    package_data={'odevalidator': ['config.ini']},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(
     author_email="fake@email.com",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'odevalidator': ['odevalidator/config.ini']},
+    package_data={'': ['odevalidator/config.ini']},
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.0.2",
     author_email="fake@email.com",
     description="ODE Data Validation Library",
-    packages=['odevalidator'],
-    package_data={'': ['config.ini']},
+    packages=find_packages(),
+    package_data={'': ['odevalidator/config.ini']},
     include_package_data=True,
 )


### PR DESCRIPTION
## Summary

Fixed a few things relating to the default config file, packaging, and some misc cleanup.

### 1. Implemented Template for Local Testing

[Testing a python package](https://riptutorial.com/python/example/18555/making-package-executable) is done by running the package as a whole like so: `python -m odevalidator`, and not by running individual files. To allow this to happen, I had to add a `__main__.py` file (similarly to `__init__.py` but fulfills a different purpose). Inside this `__main__.py` file is where all of our tests should go.

I didn't actually move that test code yet, something todo for the future.

### 2. Cleaned Default Configuration Process

I changed the default config parameter to `None`. If the user passes a config file to the `TestCase("path/to/file.file")` constructor then it will continue to use that file. If the user passes no such argument like `test_case = TestCase()` then it will load the default `config.ini` file stored in the package.

To facilitate this, I added a command to load it from `pkg_resources.resource_string`, convert it to a _text string_ (python3 apparently has two types of strings, more info discussed below), and then pass it to the `configparser.read_string(string)` function.

### 3. String vs Byte String

**Note: This is relevant to explain how the default config is loaded as a string, and to understand why json.loads() fails differently in python2 and python3.**

In python3 there are two different types of strings: character strings and byte strings. The difference between these two is encoding. Byte strings store the byte values in a binary form, and must be _decoded_ in order to be used.

If you attempt to print a byte string, you'll get a `b'` identifier: ```b'MyStringIsAString'```.

If you print a string string, you get the expected output: ```MyStringIsAString```

## Sources

(For reference)

- pkg_resources info: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#resourcemanager-api
- Running packages as a standalone script: https://riptutorial.com/python/example/18555/making-package-executable
- configparser from string: https://docs.python.org/3/library/configparser.html
- Bytes Strings vs Strings: https://www.geeksforgeeks.org/byte-objects-vs-string-python/