### PR TITLE
Remove non-iso [UTC] from the end of records with old format

### DIFF
--- a/odevalidator/sequential.py
+++ b/odevalidator/sequential.py
@@ -26,8 +26,14 @@ class Sequential:
         firstRecord = sorted_bundle[0]
         old_record_id = int(firstRecord['metadata']['serialId']['recordId'])
         old_serial_number = int(firstRecord['metadata']['serialId']['serialNumber'])
-        old_record_generated_at = dateutil.parser.parse(firstRecord['metadata']['recordGeneratedAt'])
-        old_ode_received_at = dateutil.parser.parse(firstRecord['metadata']['odeReceivedAt'])
+        old_record_generated_at_string = firstRecord['metadata']['recordGeneratedAt']
+        if old_record_generated_at_string.endswith('[UTC]'):
+            old_record_generated_at_string = old_record_generated_at_string[:-5]
+        old_record_generated_at = dateutil.parser.parse(old_record_generated_at_string)
+        old_ode_received_at_string = firstRecord['metadata']['odeReceivedAt']
+        if old_ode_received_at_string.endswith('[UTC]'):
+            old_ode_received_at_string = old_ode_received_at_string[:-5]
+        old_ode_received_at = dateutil.parser.parse(old_ode_received_at_string)
 
         record_num = 1
         validation_results = []
@@ -35,8 +41,14 @@ class Sequential:
             record_num += 1
             new_record_id = int(record['metadata']['serialId']['recordId'])
             new_serial_number = int(record['metadata']['serialId']['serialNumber'])
-            new_record_generated_at = dateutil.parser.parse(record['metadata']['recordGeneratedAt'])
-            new_ode_received_at = dateutil.parser.parse(record['metadata']['odeReceivedAt'])
+            new_record_generated_at_string = record['metadata']['recordGeneratedAt']
+            if new_record_generated_at_string.endswith('[UTC]'):
+                new_record_generated_at_string = new_record_generated_at_string[:-5]
+            new_record_generated_at = dateutil.parser.parse(new_record_generated_at_string)
+            new_ode_received_at_string = record['metadata']['odeReceivedAt']
+            if new_ode_received_at_string.endswith('[UTC]'):
+                new_ode_received_at_string = new_ode_received_at_string[:-5]
+            new_ode_received_at = dateutil.parser.parse(new_ode_received_at_string)
 
             if new_record_id != old_record_id+1:
                 validation_results.append(ValidationResult(False, "Detected incorrectly incremented recordId. Record Number: '%d' Expected recordId '%d' but got '%d'" % (record_num, old_record_id+1, new_record_id)))

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -75,6 +75,8 @@ class Field:
 
         if self.type == TYPE_TIMESTAMP:
             try:
+                if field_value.endswith('[UTC]'):
+                    field_value = field_value[:-5]
                 dateutil.parser.parse(field_value)
             except Exception as e:
                 return ValidationResult(False, "Value could not be parsed as a timestamp, error: %s" % (str(e)))
@@ -213,4 +215,3 @@ def test_file(validator, data_file):
     results = validator.validate_queue(q)
 
     return results
-


### PR DESCRIPTION
Prior to the ODE 1.0.4 release, timestamps had a `[UTC]` tag on the end. This is not standard ISO format and causes failures using python's dateutil time parser.