### PR TITLE
Remove timestamp sanity check from odeReceivedAt

### DIFF
--- a/odevalidator/config.ini
+++ b/odevalidator/config.ini
@@ -54,7 +54,6 @@ EqualsValue = {"conditions":[{"ifPart":{"fieldName":"metadata.recordGeneratedBy"
 
 [metadata.odeReceivedAt]
 Type = timestamp
-LatestTime = NOW
 
 # metadata.serialId fields
 [metadata.serialId]
@@ -86,7 +85,6 @@ EqualsValue = {"conditions":[
 
 [metadata.serialId.serialNumber]
 Type = serial
-#Increment = 1
 UpperLimit = 9223372036854775807
 LowerLimit = 0
 EqualsValue = {"conditions":[


### PR DESCRIPTION
REST API TIM messages will throw false alarms for this field with this check active, because the initialization of the object occurs before the upload.