### PR TITLE
Fix missing config

### DIFF
--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -254,7 +254,7 @@ class Field:
 
 
 class TestCase:
-    def __init__(self, filepath='odevalidator/configs/config.ini'):
+    def __init__(self, filepath=pkg_resources.resource_filename('odevalidator', 'configs/config.ini')):
         self.config = ConfigParser(interpolation=ExtendedInterpolation())
         self.record_parser = {"json": json.loads, "csv": self.parse_csv}
 

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -254,7 +254,7 @@ class Field:
 
 
 class TestCase:
-    def __init__(self, filepath=None):
+    def __init__(self, filepath='odevalidator/configs/config.ini'):
         self.config = ConfigParser(interpolation=ExtendedInterpolation())
         self.record_parser = {"json": json.loads, "csv": self.parse_csv}
 

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -259,7 +259,7 @@ class TestCase:
         self.record_parser = {"json": json.loads, "csv": self.parse_csv}
 
         if not Path(filepath).is_file():
-            raise ValidatorException("Custom configuration file '%s' could not be found" % filepath.split('/')[-1])
+            raise ValidatorException("Custom configuration file '%s' could not be found" % filepath)
         self.config.read(filepath)
 
         if self.config.has_section("_settings"):

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -254,7 +254,7 @@ class Field:
 
 
 class TestCase:
-    def __init__(self, filepath='odevalidator/configs/config.ini'):
+    def __init__(self, filepath='configs/config.ini'):
         self.config = ConfigParser(interpolation=ExtendedInterpolation())
         self.record_parser = {"json": json.loads, "csv": self.parse_csv}
 

--- a/odevalidator/validator.py
+++ b/odevalidator/validator.py
@@ -254,7 +254,7 @@ class Field:
 
 
 class TestCase:
-    def __init__(self, filepath='configs/config.ini'):
+    def __init__(self, filepath='odevalidator/configs/config.ini'):
         self.config = ConfigParser(interpolation=ExtendedInterpolation())
         self.record_parser = {"json": json.loads, "csv": self.parse_csv}
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.0.5",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'odevalidator': ['configs']},
+    package_data={'odevalidator': ['configs/config.ini']},
     include_package_data=True,
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.0.5",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'odevalidator': ['configs/*.ini']},
+    package_data={'odevalidator': ['configs/config.ini']},
     include_package_data=True,
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.0.5",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'odevalidator': ['configs/config.ini']},
+    package_data={'odevalidator': ['configs/*.ini']},
     include_package_data=True,
     test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.0.5",
     description="ODE Data Validation Library",
     packages=find_packages(),
-    package_data={'odevalidator': ['config.ini']},
+    package_data={'odevalidator': ['configs']},
     include_package_data=True,
     test_suite="tests",
 )


### PR DESCRIPTION
This change: https://github.com/usdot-jpo-ode/ode-output-validator-library/commit/de46fb7476e29390bc2f1d26b0dbf36dd203f5b9#diff-721cba01be93ca373e8c090147814e70L277 removed the ability to invoke the parameterless constructor `my_test_case = TestCase()`, so this fix adds it back.

Additionally the change to move configuration files into the `configs` folder was not updated in `setup.py` so the folder was not included in pip installs. I added a specific file path for the base file `config.ini` but did not include the rest.